### PR TITLE
fix: ensure trailing slash on matomo base url

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -74,10 +74,12 @@ useHead({
 			isNonEmptyString(env.public.NUXT_PUBLIC_MATOMO_BASE_URL) &&
 			isNonEmptyString(env.public.NUXT_PUBLIC_MATOMO_ID)
 		) {
+			const baseUrl = env.public.NUXT_PUBLIC_MATOMO_BASE_URL;
+
 			scripts.push({
 				type: "",
 				innerHTML: createAnalyticsScript(
-					env.public.NUXT_PUBLIC_MATOMO_BASE_URL,
+					baseUrl.endsWith("/") ? baseUrl : baseUrl + "/",
 					env.public.NUXT_PUBLIC_MATOMO_ID,
 				),
 			});


### PR DESCRIPTION
this ensures a trailing slash on the matomo base url, which is required by the analytics script.