### PR TITLE
Feat/static explore pages

### DIFF
--- a/content/pages/academic-reception/academic-reception.md
+++ b/content/pages/academic-reception/academic-reception.md
@@ -1,0 +1,29 @@
+---
+title: Akademische Rezeption
+sections:
+  - title: Lorem ipsum
+    content: >-
+      Elit anim cillum labore tempor Lorem irure voluptate qui nisi. Nostrud ut
+      incididunt sint laborum ad est enim do qui. Occaecat labore ea adipisicing
+      est esse enim amet irure non. Non ex et magna elit consequat cupidatat.
+      Officia velit aute voluptate velit minim ullamco. Enim laboris irure sunt
+
+      aliquip reprehenderit consequat cillum labore eiusmod ad cupidatat aliqua consectetur magna.
+
+
+      Eiusmod excepteur amet id aliqua nostrud fugiat excepteur laboris elit nulla sunt adipisicing. Magna officia eu voluptate ad amet enim laboris laborum. Ut occaecat exercitation cillum ullamco veniam consequat ea Lorem veniam. Tempor officia pariatur est tempor aliquip exercitation reprehenderit aliquip cillum in enim pariatur amet. Duis anim cupidatat nulla tempor commodo magna pariatur laboris irure.
+
+
+      Velit irure eu voluptate ipsum nulla incididunt. Consectetur veniam irure minim ea sint proident
+
+      minim nisi commodo culpa dolore ex. Cillum nostrud voluptate commodo tempor ut consectetur. Dolor cillum esse nostrud eu veniam pariatur eiusmod eiusmod enim aliquip Lorem aliqua nulla exercitation. Exercitation non fugiat ea dolore nulla. Sunt esse eiusmod qui ea. Ipsum dolore non cupidatat velit commodo et pariatur.
+
+
+      Ea reprehenderit Lorem cillum exercitation id est officia culpa irure ipsum fugiat tempor ullamco.
+
+      Elit tempor labore occaecat culpa do tempor tempor. Eiusmod anim esse tempor deserunt deserunt aute aliquip eu cupidatat ad qui incididunt mollit est. Nisi ad nisi pariatur voluptate irure minim culpa voluptate aliqua et. Velit magna consequat incididunt dolor nulla consectetur sunt pariatur enim laborum culpa deserunt.\
+
+      \
+
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+---

--- a/content/pages/autobiografiction/autobiografiction.md
+++ b/content/pages/autobiografiction/autobiografiction.md
@@ -1,0 +1,29 @@
+---
+title: Autobiografiktion
+sections:
+  - title: Lorem ipsum
+    content: >-
+      Elit anim cillum labore tempor Lorem irure voluptate qui nisi. Nostrud ut
+      incididunt sint laborum ad est enim do qui. Occaecat labore ea adipisicing
+      est esse enim amet irure non. Non ex et magna elit consequat cupidatat.
+      Officia velit aute voluptate velit minim ullamco. Enim laboris irure sunt
+
+      aliquip reprehenderit consequat cillum labore eiusmod ad cupidatat aliqua consectetur magna.
+
+
+      Eiusmod excepteur amet id aliqua nostrud fugiat excepteur laboris elit nulla sunt adipisicing. Magna officia eu voluptate ad amet enim laboris laborum. Ut occaecat exercitation cillum ullamco veniam consequat ea Lorem veniam. Tempor officia pariatur est tempor aliquip exercitation reprehenderit aliquip cillum in enim pariatur amet. Duis anim cupidatat nulla tempor commodo magna pariatur laboris irure.
+
+
+      Velit irure eu voluptate ipsum nulla incididunt. Consectetur veniam irure minim ea sint proident
+
+      minim nisi commodo culpa dolore ex. Cillum nostrud voluptate commodo tempor ut consectetur. Dolor cillum esse nostrud eu veniam pariatur eiusmod eiusmod enim aliquip Lorem aliqua nulla exercitation. Exercitation non fugiat ea dolore nulla. Sunt esse eiusmod qui ea. Ipsum dolore non cupidatat velit commodo et pariatur.
+
+
+      Ea reprehenderit Lorem cillum exercitation id est officia culpa irure ipsum fugiat tempor ullamco.
+
+      Elit tempor labore occaecat culpa do tempor tempor. Eiusmod anim esse tempor deserunt deserunt aute aliquip eu cupidatat ad qui incididunt mollit est. Nisi ad nisi pariatur voluptate irure minim culpa voluptate aliqua et. Velit magna consequat incididunt dolor nulla consectetur sunt pariatur enim laborum culpa deserunt.\
+
+      \
+
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+---

--- a/content/pages/from-the-archive/from-the-archive.md
+++ b/content/pages/from-the-archive/from-the-archive.md
@@ -1,0 +1,29 @@
+---
+title: Aus dem Archiv
+sections:
+  - title: Lorem ipsum
+    content: >-
+      Elit anim cillum labore tempor Lorem irure voluptate qui nisi. Nostrud ut
+      incididunt sint laborum ad est enim do qui. Occaecat labore ea adipisicing
+      est esse enim amet irure non. Non ex et magna elit consequat cupidatat.
+      Officia velit aute voluptate velit minim ullamco. Enim laboris irure sunt
+
+      aliquip reprehenderit consequat cillum labore eiusmod ad cupidatat aliqua consectetur magna.
+
+
+      Eiusmod excepteur amet id aliqua nostrud fugiat excepteur laboris elit nulla sunt adipisicing. Magna officia eu voluptate ad amet enim laboris laborum. Ut occaecat exercitation cillum ullamco veniam consequat ea Lorem veniam. Tempor officia pariatur est tempor aliquip exercitation reprehenderit aliquip cillum in enim pariatur amet. Duis anim cupidatat nulla tempor commodo magna pariatur laboris irure.
+
+
+      Velit irure eu voluptate ipsum nulla incididunt. Consectetur veniam irure minim ea sint proident
+
+      minim nisi commodo culpa dolore ex. Cillum nostrud voluptate commodo tempor ut consectetur. Dolor cillum esse nostrud eu veniam pariatur eiusmod eiusmod enim aliquip Lorem aliqua nulla exercitation. Exercitation non fugiat ea dolore nulla. Sunt esse eiusmod qui ea. Ipsum dolore non cupidatat velit commodo et pariatur.
+
+
+      Ea reprehenderit Lorem cillum exercitation id est officia culpa irure ipsum fugiat tempor ullamco.
+
+      Elit tempor labore occaecat culpa do tempor tempor. Eiusmod anim esse tempor deserunt deserunt aute aliquip eu cupidatat ad qui incididunt mollit est. Nisi ad nisi pariatur voluptate irure minim culpa voluptate aliqua et. Velit magna consequat incididunt dolor nulla consectetur sunt pariatur enim laborum culpa deserunt.\
+
+      \
+
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+---

--- a/content/pages/glossary/glossary.md
+++ b/content/pages/glossary/glossary.md
@@ -1,0 +1,11 @@
+---
+title: Glossar
+---
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.

--- a/content/pages/journalistic-reception/journalistic-reception.md
+++ b/content/pages/journalistic-reception/journalistic-reception.md
@@ -1,0 +1,47 @@
+---
+title: Journalistische Rezeption
+sections:
+  - title: Lorem ipsum
+    content: >-
+      Elit anim cillum labore tempor Lorem irure voluptate qui nisi. Nostrud ut incididunt sint
+      laborum ad est enim do qui. Occaecat labore ea adipisicing est esse enim amet irure non. Non
+      ex et magna elit consequat cupidatat. Officia velit aute voluptate velit minim ullamco. Enim
+      laboris irure sunt
+
+      aliquip reprehenderit consequat cillum labore eiusmod ad cupidatat aliqua consectetur magna.
+
+
+      Eiusmod excepteur amet id aliqua nostrud fugiat excepteur laboris elit nulla sunt adipisicing.
+      Magna officia eu voluptate ad amet enim laboris laborum. Ut occaecat exercitation cillum
+      ullamco veniam consequat ea Lorem veniam. Tempor officia pariatur est tempor aliquip
+      exercitation reprehenderit aliquip cillum in enim pariatur amet. Duis anim cupidatat nulla
+      tempor commodo magna pariatur laboris irure.
+
+
+      Velit irure eu voluptate ipsum nulla incididunt. Consectetur veniam irure minim ea sint
+      proident
+
+      minim nisi commodo culpa dolore ex. Cillum nostrud voluptate commodo tempor ut consectetur.
+      Dolor cillum esse nostrud eu veniam pariatur eiusmod eiusmod enim aliquip Lorem aliqua nulla
+      exercitation. Exercitation non fugiat ea dolore nulla. Sunt esse eiusmod qui ea. Ipsum dolore
+      non cupidatat velit commodo et pariatur.
+
+
+      Ea reprehenderit Lorem cillum exercitation id est officia culpa irure ipsum fugiat tempor
+      ullamco.
+
+      Elit tempor labore occaecat culpa do tempor tempor. Eiusmod anim esse tempor deserunt deserunt
+      aute aliquip eu cupidatat ad qui incididunt mollit est. Nisi ad nisi pariatur voluptate irure
+      minim culpa voluptate aliqua et. Velit magna consequat incididunt dolor nulla consectetur sunt
+      pariatur enim laborum culpa deserunt.\
+
+      \
+
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+      invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et
+      justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+      ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+      eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+      et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+      sanctus est Lorem ipsum dolor sit amet.
+---

--- a/content/pages/places/places.md
+++ b/content/pages/places/places.md
@@ -1,0 +1,11 @@
+---
+title: Orte
+---
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.

--- a/content/pages/quotes/zitat-1.md
+++ b/content/pages/quotes/zitat-1.md
@@ -1,0 +1,5 @@
+---
+title: Zitat 1
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/19360
+---
+"Und dann fiel ich aus den Wolken."

--- a/content/pages/quotes/zitat-2.md
+++ b/content/pages/quotes/zitat-2.md
@@ -1,0 +1,5 @@
+---
+title: Zitat 2
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/19396
+---
+"Keine Grenze kann so dicht geschlossen werden, dass sie nicht von denen, die unbedingt ihr Glück versuchen wollen, überwunden wird."

--- a/content/pages/quotes/zitat-3.md
+++ b/content/pages/quotes/zitat-3.md
@@ -1,0 +1,5 @@
+---
+title: Zitat 3
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/26300
+---
+"Für die meisten Schriftsteller gibt es ohnehin nur eine wirkliche Heimat, und das ist die Sprache, in der sie schreiben."

--- a/content/pages/quotes/zitat-4.md
+++ b/content/pages/quotes/zitat-4.md
@@ -1,0 +1,5 @@
+---
+title: Zitat 4
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/19633
+---
+"Was kannst du dir denn sonst vom Leben mitnehmen als das Lachen!"

--- a/content/pages/quotes/zitat-5.md
+++ b/content/pages/quotes/zitat-5.md
@@ -1,0 +1,6 @@
+---
+title: Zitat 5
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/19724
+---
+
+"Doch was bedeutet Klarheit, wenn die Verhältnisse immer undurchschaubarer werden?"

--- a/content/pages/quotes/zitat-6.md
+++ b/content/pages/quotes/zitat-6.md
@@ -1,0 +1,5 @@
+---
+title: Zitat 6
+link: https://frischmuth-frontend.acdh-ch-dev.oeaw.ac.at/work/26268
+---
+"Die Natur zu unterschätzen, wäre lebensgefährlich. Sie zu schätzen, ja zu lieben, eine menschenwürdige Erkenntnis."

--- a/content/pages/research-aspects/research-aspects.md
+++ b/content/pages/research-aspects/research-aspects.md
@@ -1,0 +1,11 @@
+---
+title: Forschungshinsichten
+---
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.

--- a/content/pages/themes/themes.md
+++ b/content/pages/themes/themes.md
@@ -1,0 +1,11 @@
+---
+title: Themen
+---
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.

--- a/messages/de/index.json
+++ b/messages/de/index.json
@@ -9,6 +9,46 @@
 		},
 		"title": "Über das Projekt"
 	},
+	"AcademicReceptionPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Akademische Rezeption"
+		},
+		"title": "Akademische Rezeption"
+	},
+	"JournalisticReceptionPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Journalistische Rezeption"
+		},
+		"title": "Journalistische Rezeption"
+	},
+	"AutobiografictionPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Autobiografiktion"
+		},
+		"title": "Autobiografiktion"
+	},
+	"FromTheArchivePage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Aus dem Archiv"
+		},
+		"title": "Aus dem Archiv"
+	},
 	"BiographyPage": {
 		"errors": {
 			"404": "Seite nicht gefunden",

--- a/messages/de/index.json
+++ b/messages/de/index.json
@@ -19,6 +19,16 @@
 		},
 		"title": "Akademische Rezeption"
 	},
+	"AltausseePage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Altaussee"
+		},
+		"title": "Altaussee"
+	},
 	"JournalisticReceptionPage": {
 		"errors": {
 			"404": "Seite nicht gefunden",

--- a/messages/de/index.json
+++ b/messages/de/index.json
@@ -59,6 +59,46 @@
 		},
 		"title": "Biografie"
 	},
+	"PlacesPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Orte"
+		},
+		"title": "Orte"
+	},
+	"ThemesPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Themen"
+		},
+		"title": "Themen"
+	},
+	"GlossaryPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Glossar"
+		},
+		"title": "Glossar"
+	},
+	"ResearchAspectsPage": {
+		"errors": {
+			"404": "Seite nicht gefunden",
+			"500": "Interner Fehler"
+		},
+		"meta": {
+			"title": "Forschungs-Hinsichten"
+		},
+		"title": "Forschungs-Hinsichten"
+	},
 	"AppFooter": {
 		"links": {
 			"imprint": "Impressum"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,11 +1,22 @@
 import { fileURLToPath } from "node:url";
 
+import babel from "vite-plugin-babel";
+
 import { defaultLocale, localesMap } from "./config/i18n.config";
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const baseUrl = process.env.NUXT_PUBLIC_APP_BASE_URL!;
 
 export default defineNuxtConfig({
+	vite: {
+		plugins: [
+			babel({
+				babelConfig: {
+					plugins: ["@babel/plugin-transform-named-capturing-groups-regex"],
+				},
+			}),
+		],
+	},
 	alias: {
 		"@": fileURLToPath(new URL("./", import.meta.url)),
 	},

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,22 +1,11 @@
 import { fileURLToPath } from "node:url";
 
-import babel from "vite-plugin-babel";
-
 import { defaultLocale, localesMap } from "./config/i18n.config";
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const baseUrl = process.env.NUXT_PUBLIC_APP_BASE_URL!;
 
 export default defineNuxtConfig({
-	vite: {
-		plugins: [
-			babel({
-				babelConfig: {
-					plugins: ["@babel/plugin-transform-named-capturing-groups-regex"],
-				},
-			}),
-		],
-	},
 	alias: {
 		"@": fileURLToPath(new URL("./", import.meta.url)),
 	},

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@nuxtjs/color-mode": "^3.5.2",
 		"@nuxtjs/i18n": "^8.5.5",
 		"@radix-icons/vue": "^1.0.0",
+		"@stefanprobst/netlify-cms-oauth-client": "^0.4.0",
 		"@tailwindcss/typography": "^0.5.15",
 		"@tanstack/vue-query": "^5.59.16",
 		"@tanstack/vue-table": "^8.20.5",
@@ -65,7 +66,6 @@
 		"remark-parse": "^11.0.0",
 		"satori": "^0.10.14",
 		"shadcn-vue": "^0.10.5",
-		"@stefanprobst/netlify-cms-oauth-client": "^0.4.0",
 		"tailwind-merge": "^2.5.4",
 		"tailwindcss-animate": "^1.0.7",
 		"valibot": "^0.37.0",
@@ -84,6 +84,7 @@
 		"@acdh-oeaw/prettier-config": "^1.0.1",
 		"@acdh-oeaw/stylelint-config": "^2.0.4",
 		"@acdh-oeaw/tsconfig": "^1.2.0",
+		"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
 		"@nuxt/devtools": "^1.6.0",
 		"@playwright/test": "^1.48.1",
 		"@types/node": "^20.17.0",
@@ -110,6 +111,7 @@
 		"tsx": "^4.19.1",
 		"typescript": "^5.6.3",
 		"vite": "^5.4.10",
+		"vite-plugin-babel": "^1.3.0",
 		"vue-tsc": "^2.1.6"
 	},
 	"browserslist": {

--- a/pages/explore/academic-reception.vue
+++ b/pages/explore/academic-reception.vue
@@ -10,13 +10,13 @@ defineRouteRules({
 const t = useTranslations();
 
 usePageMetadata({
-	title: t("AboutPage.meta.title"),
+	title: t("AcademicReceptionPage.meta.title"),
 });
 
 const { data: about, error: aboutError } = useQuery({
-	queryKey: ["about"] as const,
+	queryKey: ["academic-reception"] as const,
 	queryFn() {
-		return queryContent<StaticPage>("pages/about/about-the-project").findOne();
+		return queryContent<StaticPage>("pages/academic-reception/academic-reception").findOne();
 	},
 });
 
@@ -38,8 +38,8 @@ watch(
 );
 
 useErrorMessage(aboutError, {
-	notFound: t("AboutPage.errors.404"),
-	unknown: t("AboutPage.errors.500"),
+	notFound: t("AcademicReceptionPage"),
+	unknown: t("AcademicReceptionPage.errors.500"),
 });
 </script>
 
@@ -49,8 +49,8 @@ useErrorMessage(aboutError, {
 	>
 		<div class="flex md:justify-end">
 			<Card class="aspect-square size-full bg-frisch-grey md:size-72">
-				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
-					<h1 class="uppercase">{{ t("AboutPage.title") }}</h1>
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-frisch-indigo">
+					<h1>{{ t("AcademicReceptionPage.title") }}</h1>
 				</CardContent>
 			</Card>
 		</div>

--- a/pages/explore/autobiografiction.vue
+++ b/pages/explore/autobiografiction.vue
@@ -10,13 +10,13 @@ defineRouteRules({
 const t = useTranslations();
 
 usePageMetadata({
-	title: t("AboutPage.meta.title"),
+	title: t("AutobiografictionPage.meta.title"),
 });
 
 const { data: about, error: aboutError } = useQuery({
-	queryKey: ["about"] as const,
+	queryKey: ["autobiografiction"] as const,
 	queryFn() {
-		return queryContent<StaticPage>("pages/about/about-the-project").findOne();
+		return queryContent<StaticPage>("pages/autobiografiction/autobiografiction").findOne();
 	},
 });
 
@@ -38,8 +38,8 @@ watch(
 );
 
 useErrorMessage(aboutError, {
-	notFound: t("AboutPage.errors.404"),
-	unknown: t("AboutPage.errors.500"),
+	notFound: t("AutobiografictionPage.errors.404"),
+	unknown: t("AutobiografictionPage.errors.500"),
 });
 </script>
 
@@ -49,8 +49,8 @@ useErrorMessage(aboutError, {
 	>
 		<div class="flex md:justify-end">
 			<Card class="aspect-square size-full bg-frisch-grey md:size-72">
-				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
-					<h1 class="uppercase">{{ t("AboutPage.title") }}</h1>
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-frisch-indigo">
+					<h1>{{ t("AutobiografictionPage.title") }}</h1>
 				</CardContent>
 			</Card>
 		</div>

--- a/pages/explore/biography.vue
+++ b/pages/explore/biography.vue
@@ -41,7 +41,7 @@ const sortedEntries = computed(() => {
 		class="grid gap-8 p-4 md:grid-cols-[1fr_3fr] md:justify-center md:px-12 2xl:grid-cols-[2fr_3fr]"
 	>
 		<div class="flex md:justify-end">
-			<Card class="aspect-square size-full bg-frisch-orange md:size-72">
+			<Card class="aspect-square size-full bg-frisch-indigo md:size-72">
 				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
 					<h1 class="uppercase">Biografie</h1>
 				</CardContent>

--- a/pages/explore/from-the-archive.vue
+++ b/pages/explore/from-the-archive.vue
@@ -10,13 +10,13 @@ defineRouteRules({
 const t = useTranslations();
 
 usePageMetadata({
-	title: t("AboutPage.meta.title"),
+	title: t("FromTheArchivePage.meta.title"),
 });
 
 const { data: about, error: aboutError } = useQuery({
-	queryKey: ["about"] as const,
+	queryKey: ["from-the-archive"] as const,
 	queryFn() {
-		return queryContent<StaticPage>("pages/about/about-the-project").findOne();
+		return queryContent<StaticPage>("pages/from-the-archive/from-the-archive").findOne();
 	},
 });
 
@@ -38,8 +38,8 @@ watch(
 );
 
 useErrorMessage(aboutError, {
-	notFound: t("AboutPage.errors.404"),
-	unknown: t("AboutPage.errors.500"),
+	notFound: t("FromTheArchivePage.errors.404"),
+	unknown: t("FromTheArchivePage.errors.500"),
 });
 </script>
 
@@ -49,8 +49,8 @@ useErrorMessage(aboutError, {
 	>
 		<div class="flex md:justify-end">
 			<Card class="aspect-square size-full bg-frisch-grey md:size-72">
-				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
-					<h1 class="uppercase">{{ t("AboutPage.title") }}</h1>
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-frisch-indigo">
+					<h1>{{ t("FromTheArchivePage.title") }}</h1>
 				</CardContent>
 			</Card>
 		</div>

--- a/pages/explore/glossary.vue
+++ b/pages/explore/glossary.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { useQuery } from "@tanstack/vue-query";
+
+defineRouteRules({
+	prerender: true,
+});
+
+const t = useTranslations();
+
+usePageMetadata({
+	title: t("GlossaryPage"),
+});
+
+const { data: glossary, error: aboutError } = useQuery({
+	queryKey: ["glossary"] as const,
+	queryFn() {
+		return queryContent("pages/glossary/glossary").findOne();
+	},
+});
+
+useErrorMessage(aboutError, {
+	notFound: t("GlossaryPage.errors.404"),
+	unknown: t("GlossaryPage.errors.500"),
+});
+</script>
+
+<template>
+	<MainContent
+		class="grid gap-8 p-4 md:grid-cols-[1fr_3fr] md:justify-center md:px-12 2xl:grid-cols-[2fr_3fr]"
+	>
+		<div class="flex md:justify-end">
+			<Card class="aspect-square size-full bg-frisch-orange md:size-72">
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
+					<h1 class="uppercase">{{ t("GlossaryPage.title") }}</h1>
+				</CardContent>
+			</Card>
+		</div>
+
+		<ContentRenderer v-if="glossary" class="prose max-w-3xl" :value="glossary">
+			<template #empty></template>
+		</ContentRenderer>
+	</MainContent>
+</template>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -1,9 +1,45 @@
 <script lang="ts" setup>
+import { useQuery } from "@tanstack/vue-query";
+
+import type { Quote } from "@/types/content";
+
 defineRouteRules({
 	prerender: true,
 });
 
 const t = useTranslations();
+
+function getRandomEntries(arr: Array<Quote>, count: number) {
+	if (arr.length <= count) return arr;
+
+	const shuffled = arr
+		.map((value) => ({ value, sortKey: Math.random() }))
+		.sort((a, b) => a.sortKey - b.sortKey)
+		.map(({ value }) => value);
+
+	return shuffled.slice(0, count);
+}
+
+const {
+	data: quotes,
+	isLoading: isLoading,
+	error: quotesError,
+} = useQuery({
+	queryKey: ["quotes"],
+	queryFn() {
+		return queryContent<Quote>("pages/quotes").find();
+	},
+});
+
+const randomQuotes = ref<Quote[]>([]);
+
+watchEffect(() => {
+	if (quotes.value) {
+		randomQuotes.value = getRandomEntries(quotes.value, 3);
+	}
+});
+
+const quotesReady = computed(() => randomQuotes.value.length > 0);
 
 usePageMetadata({
 	title: t("ExplorePage.meta.title"),
@@ -29,11 +65,19 @@ usePageMetadata({
 				>
 					<span>Journalistische Rezeption</span>
 				</NuxtLink>
-				<Card
+				<NuxtLink
+					:to="randomQuotes[0]?.link || ''"
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
 				>
-					<span>"Und dann fiel ich aus den Wolken"</span>
-				</Card>
+					<template v-if="randomQuotes[0] != null">
+						<ContentRenderer :value="randomQuotes[0]" />
+					</template>
+					<template v-else>
+						<span class="flex h-full w-full items-center justify-center text-sm text-frisch-orange">
+							<LoadingSpinner />
+						</span>
+					</template>
+				</NuxtLink>
 				<NuxtLink
 					to="/explore/research-aspects"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
@@ -65,14 +109,19 @@ usePageMetadata({
 				>
 					<span class="relative">ALTAUSSEE</span>
 				</Card>
-				<Card
+				<NuxtLink
+					:to="randomQuotes[1]?.link || ''"
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
 				>
-					<span>
-						"Keine Grenze kann so dicht geschlossen werden, dass sie nicht von denen, die unbedingt
-						ihr Glück versuchen wollen, überwunden wird.
-					</span>
-				</Card>
+					<template v-if="randomQuotes[1] != null">
+						<ContentRenderer :value="randomQuotes[1]" />
+					</template>
+					<template v-else>
+						<span class="flex h-full w-full items-center justify-center text-frisch-orange">
+							<LoadingSpinner />
+						</span>
+					</template>
+				</NuxtLink>
 				<NuxtLink
 					to="/explore/glossary"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
@@ -85,14 +134,19 @@ usePageMetadata({
 				>
 					<span>BIOGRAFIE</span>
 				</NuxtLink>
-				<Card
+				<NuxtLink
+					:to="randomQuotes[2]?.link || ''"
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
 				>
-					<span>
-						"Für die meisten Schriftsteller gibt es ohnehin nur eine wirkliche Heimat, und das ist
-						die Sprache, in der sie schreiben."
-					</span>
-				</Card>
+					<template v-if="randomQuotes[2] != null">
+						<ContentRenderer :value="randomQuotes[2]" />
+					</template>
+					<template v-else>
+						<span class="flex h-full w-full items-center justify-center text-sm text-frisch-orange">
+							<LoadingSpinner />
+						</span>
+					</template>
+				</NuxtLink>
 				<NuxtLink
 					to="/explore/autobiografiction"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -20,18 +20,14 @@ function getRandomEntries(arr: Array<Quote>, count: number) {
 	return shuffled.slice(0, count);
 }
 
-const {
-	data: quotes,
-	isLoading: isLoading,
-	error: quotesError,
-} = useQuery({
+const { data: quotes } = useQuery({
 	queryKey: ["quotes"],
 	queryFn() {
 		return queryContent<Quote>("pages/quotes").find();
 	},
 });
 
-const randomQuotes = ref<Quote[]>([]);
+const randomQuotes = ref<Array<Quote>>([]);
 
 watchEffect(() => {
 	if (quotes.value) {
@@ -39,135 +35,147 @@ watchEffect(() => {
 	}
 });
 
-const quotesReady = computed(() => randomQuotes.value.length > 0);
-
 usePageMetadata({
 	title: t("ExplorePage.meta.title"),
 });
 </script>
 
 <template>
-	<MainContent class="container p-4 lg:py-8">
+	<MainContent class="container grid content-center items-center p-4 lg:py-8">
 		<h1 class="sr-only">{{ t("ExplorePage.title") }}</h1>
-		<div class="mx-auto flex size-full max-h-full items-center justify-center font-semibold">
-			<div
-				class="mx-auto grid max-h-full grid-cols-2 gap-2 font-bold lg:gap-4 lg:text-2xl lg:grid-fluid-cols-72"
+		<div
+			class="grid max-h-full grid-cols-2 gap-2 font-bold lg:gap-4 lg:text-2xl lg:grid-fluid-cols-72"
+		>
+			<NuxtLink
+				to="/explore/places"
+				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 			>
-				<NuxtLink
-					to="/explore/places"
-					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
-				>
-					<span>ORTE</span>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/journalistic-reception"
-					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
-				>
-					<span>Journalistische Rezeption</span>
-				</NuxtLink>
-				<NuxtLink
-					:to="randomQuotes[0]?.link || ''"
-					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
-				>
-					<template v-if="randomQuotes[0] != null">
-						<ContentRenderer :value="randomQuotes[0]" />
-					</template>
-					<template v-else>
-						<span class="flex h-full w-full items-center justify-center text-sm text-frisch-orange">
-							<LoadingSpinner />
-						</span>
-					</template>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/research-aspects"
-					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
-				>
-					<span>FORSCHUNGS-HINSICHTEN</span>
-				</NuxtLink>
-				<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
-					<NuxtImg
-						alt=""
-						preload
-						src="/assets/images/writing_placeholder.png"
-						class="absolute inset-0 size-full object-cover"
-					/>
-				</Card>
-				<NuxtLink
-					to="/explore/from-the-archive"
-					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
-				>
-					<span>Aus dem Archiv</span>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/themes"
-					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
-				>
-					<span>THEMEN</span>
-				</NuxtLink>
-				<Card
-					class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
-				>
-					<span class="relative">ALTAUSSEE</span>
-				</Card>
-				<NuxtLink
-					:to="randomQuotes[1]?.link || ''"
-					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
-				>
-					<template v-if="randomQuotes[1] != null">
-						<ContentRenderer :value="randomQuotes[1]" />
-					</template>
-					<template v-else>
-						<span class="flex h-full w-full items-center justify-center text-frisch-orange">
-							<LoadingSpinner />
-						</span>
-					</template>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/glossary"
-					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
-				>
-					<span>GLOSSAR</span>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/biography"
-					class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
-				>
-					<span>BIOGRAFIE</span>
-				</NuxtLink>
-				<NuxtLink
-					:to="randomQuotes[2]?.link || ''"
-					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
-				>
-					<template v-if="randomQuotes[2] != null">
-						<ContentRenderer :value="randomQuotes[2]" />
-					</template>
-					<template v-else>
-						<span class="flex h-full w-full items-center justify-center text-sm text-frisch-orange">
-							<LoadingSpinner />
-						</span>
-					</template>
-				</NuxtLink>
-				<NuxtLink
-					to="/explore/autobiografiction"
-					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
-				>
-					<span>Autobiografiktion</span>
-				</NuxtLink>
-				<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
-					<NuxtImg
-						alt=""
-						preload
-						src="/assets/images/writing_placeholder.png"
-						class="absolute inset-0 size-full object-cover"
-					/>
-				</Card>
-				<NuxtLink
-					to="/explore/academic-reception"
-					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
-				>
-					<span>Akademische Rezeption</span>
-				</NuxtLink>
-			</div>
+				<span>ORTE</span>
+			</NuxtLink>
+			<NuxtLink
+				to="/explore/journalistic-reception"
+				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
+			>
+				<span>Journalistische Rezeption</span>
+			</NuxtLink>
+			<NuxtLink
+				rel="noopener noreferrer"
+				:to="randomQuotes[0]?.link || ''"
+				class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
+			>
+				<span class="sr-only">
+					{{ randomQuotes[0]?.text || "Loading content..." }}
+				</span>
+
+				<template v-if="randomQuotes[0] != null">
+					<ContentRenderer class="text-frisch-orange" :value="randomQuotes[0]" />
+				</template>
+				<template v-else>
+					<span class="flex size-full items-center justify-center text-sm text-frisch-orange">
+						<LoadingSpinner />
+					</span>
+				</template>
+			</NuxtLink>
+			<NuxtLink
+				to="/explore/research-aspects"
+				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
+			>
+				<span>FORSCHUNGS-HINSICHTEN</span>
+			</NuxtLink>
+			<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
+				<NuxtImg
+					alt=""
+					preload
+					src="/assets/images/writing_placeholder.png"
+					class="absolute inset-0 size-full object-cover"
+				/>
+			</Card>
+			<NuxtLink
+				to="/explore/from-the-archive"
+				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
+			>
+				<span>Aus dem Archiv</span>
+			</NuxtLink>
+			<NuxtLink
+				to="/explore/themes"
+				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
+			>
+				<span>THEMEN</span>
+			</NuxtLink>
+			<Card
+				class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
+			>
+				<span class="relative">ALTAUSSEE</span>
+			</Card>
+			<NuxtLink
+				rel="noopener noreferrer"
+				:to="randomQuotes[1]?.link || ''"
+				class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
+			>
+				<span class="sr-only">
+					{{ randomQuotes[1]?.text || "Loading content..." }}
+				</span>
+
+				<template v-if="randomQuotes[1] != null">
+					<ContentRenderer class="text-frisch-orange" :value="randomQuotes[1]" />
+				</template>
+				<template v-else>
+					<span class="flex size-full items-center justify-center text-sm text-frisch-orange">
+						<LoadingSpinner />
+					</span>
+				</template>
+			</NuxtLink>
+			<NuxtLink
+				to="/explore/academic-reception"
+				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
+			>
+				<span>Akademische Rezeption</span>
+			</NuxtLink>
+
+			<NuxtLink
+				to="/explore/biography"
+				class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
+			>
+				<span>BIOGRAFIE</span>
+			</NuxtLink>
+			<NuxtLink
+				rel="noopener noreferrer"
+				:to="randomQuotes[2]?.link || ''"
+				class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
+			>
+				<span class="sr-only">
+					{{ randomQuotes[2]?.text || "Loading content..." }}
+				</span>
+
+				<template v-if="randomQuotes[2] != null">
+					<ContentRenderer class="text-frisch-orange" :value="randomQuotes[2]" />
+				</template>
+				<template v-else>
+					<span class="flex size-full items-center justify-center text-sm text-frisch-orange">
+						<LoadingSpinner />
+					</span>
+				</template>
+			</NuxtLink>
+			<NuxtLink
+				to="/explore/autobiografiction"
+				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
+			>
+				<span>Autobiografiktion</span>
+			</NuxtLink>
+			<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
+				<NuxtImg
+					alt=""
+					preload
+					src="/assets/images/writing_placeholder.png"
+					class="absolute inset-0 size-full object-cover"
+				/>
+			</Card>
+			<NuxtLink
+				to="/explore/glossary"
+				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
+			>
+				<span>GLOSSAR</span>
+			</NuxtLink>
 		</div>
 	</MainContent>
 </template>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -17,11 +17,12 @@ usePageMetadata({
 			<div
 				class="mx-auto grid max-h-full grid-cols-2 gap-2 font-bold lg:gap-4 lg:text-2xl lg:grid-fluid-cols-72"
 			>
-				<Card
+				<NuxtLink
+					to="/explore/places"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
 					<span>ORTE</span>
-				</Card>
+				</NuxtLink>
 				<NuxtLink
 					to="/explore/journalistic-reception"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
@@ -33,16 +34,18 @@ usePageMetadata({
 				>
 					<span>"Und dann fiel ich aus den Wolken"</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/research-aspects"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
 					<span>FORSCHUNGS-HINSICHTEN</span>
-				</Card>
+				</NuxtLink>
 				<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
-					<img
+					<NuxtImg
 						alt=""
-						class="absolute inset-0 size-full object-cover"
+						preload
 						src="/assets/images/writing_placeholder.png"
+						class="absolute inset-0 size-full object-cover"
 					/>
 				</Card>
 				<NuxtLink
@@ -52,7 +55,7 @@ usePageMetadata({
 					<span>Aus dem Archiv</span>
 				</NuxtLink>
 				<NuxtLink
-					to="/"
+					to="/explore/themes"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
 					<span>THEMEN</span>
@@ -70,11 +73,12 @@ usePageMetadata({
 						ihr Glück versuchen wollen, überwunden wird.
 					</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/glossary"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
 					<span>GLOSSAR</span>
-				</Card>
+				</NuxtLink>
 				<NuxtLink
 					to="/explore/biography"
 					class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
@@ -95,10 +99,13 @@ usePageMetadata({
 				>
 					<span>Autobiografiktion</span>
 				</NuxtLink>
-				<Card
-					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
-				>
-					<span>INTERPRETATEME</span>
+				<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
+					<NuxtImg
+						alt=""
+						preload
+						src="/assets/images/writing_placeholder.png"
+						class="absolute inset-0 size-full object-cover"
+					/>
 				</Card>
 				<NuxtLink
 					to="/explore/academic-reception"

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -22,11 +22,12 @@ usePageMetadata({
 				>
 					<span>ORTE</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/journalistic-reception"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 				>
-					<span class="relative">Istanbul</span>
-				</Card>
+					<span>Journalistische Rezeption</span>
+				</NuxtLink>
 				<Card
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
 				>
@@ -44,21 +45,22 @@ usePageMetadata({
 						src="/assets/images/writing_placeholder.png"
 					/>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/from-the-archive"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 				>
 					<span>Aus dem Archiv</span>
-				</Card>
+				</NuxtLink>
 				<NuxtLink
-					to="/biography"
+					to="/"
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
-					<span>BIOGRAFIE</span>
+					<span>THEMEN</span>
 				</NuxtLink>
 				<Card
 					class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
 				>
-					<span>JOURNALISTISCHE REZEPTION</span>
+					<span class="relative">ALTAUSSEE</span>
 				</Card>
 				<Card
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
@@ -73,11 +75,12 @@ usePageMetadata({
 				>
 					<span>GLOSSAR</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/biography"
 					class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
 				>
-					<span>AKADEMISCHE REZEPTION</span>
-				</Card>
+					<span>BIOGRAFIE</span>
+				</NuxtLink>
 				<Card
 					class="relative aspect-square overflow-hidden bg-frisch-orange-light p-4 text-frisch-orange transition hover:scale-105"
 				>
@@ -86,21 +89,23 @@ usePageMetadata({
 						die Sprache, in der sie schreiben."
 					</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/autobiografiction"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 				>
-					<span>Postkoloniale Theorie</span>
-				</Card>
+					<span>Autobiografiktion</span>
+				</NuxtLink>
 				<Card
 					class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 				>
 					<span>INTERPRETATEME</span>
 				</Card>
-				<Card
+				<NuxtLink
+					to="/explore/academic-reception"
 					class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 				>
-					<span>Kasanapodole</span>
-				</Card>
+					<span>Akademische Rezeption</span>
+				</NuxtLink>
 			</div>
 		</div>
 	</MainContent>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -50,13 +50,13 @@ usePageMetadata({
 				to="/explore/places"
 				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 			>
-				<span>ORTE</span>
+				<span class="uppercase">{{ t("PlacesPage.title") }}</span>
 			</NuxtLink>
 			<NuxtLink
 				to="/explore/journalistic-reception"
 				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 			>
-				<span>Journalistische Rezeption</span>
+				<span>{{ t("JournalisticReceptionPage.title") }}</span>
 			</NuxtLink>
 			<NuxtLink
 				rel="noopener noreferrer"
@@ -80,7 +80,7 @@ usePageMetadata({
 				to="/explore/research-aspects"
 				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 			>
-				<span>FORSCHUNGS-HINSICHTEN</span>
+				<span class="uppercase">{{ t("ResearchAspectsPage.title") }}</span>
 			</NuxtLink>
 			<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
 				<NuxtImg
@@ -94,18 +94,18 @@ usePageMetadata({
 				to="/explore/from-the-archive"
 				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 			>
-				<span>Aus dem Archiv</span>
+				<span>{{ t("FromTheArchivePage.title") }}</span>
 			</NuxtLink>
 			<NuxtLink
 				to="/explore/themes"
 				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 			>
-				<span>THEMEN</span>
+				<span class="uppercase">{{ t("ThemesPage.title") }}</span>
 			</NuxtLink>
 			<Card
 				class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
 			>
-				<span class="relative">ALTAUSSEE</span>
+				<span class="uppercase">{{ t("AltausseePage.title") }}</span>
 			</Card>
 			<NuxtLink
 				rel="noopener noreferrer"
@@ -129,14 +129,14 @@ usePageMetadata({
 				to="/explore/academic-reception"
 				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 			>
-				<span>Akademische Rezeption</span>
+				<span>{{ t("AcademicReceptionPage.title") }}</span>
 			</NuxtLink>
 
 			<NuxtLink
 				to="/explore/biography"
 				class="relative aspect-square overflow-hidden bg-frisch-indigo p-4 text-white transition hover:scale-105"
 			>
-				<span>BIOGRAFIE</span>
+				<span class="uppercase">{{ t("BiographyPage.title") }}</span>
 			</NuxtLink>
 			<NuxtLink
 				rel="noopener noreferrer"
@@ -160,7 +160,7 @@ usePageMetadata({
 				to="/explore/autobiografiction"
 				class="relative aspect-square overflow-hidden bg-frisch-grey p-4 text-frisch-indigo transition hover:scale-105"
 			>
-				<span>Autobiografiktion</span>
+				<span>{{ t("AutobiografictionPage.title") }}</span>
 			</NuxtLink>
 			<Card class="relative aspect-square overflow-hidden p-4 transition hover:scale-105">
 				<NuxtImg
@@ -174,7 +174,7 @@ usePageMetadata({
 				to="/explore/glossary"
 				class="relative aspect-square overflow-hidden bg-frisch-orange p-4 text-white transition hover:scale-105"
 			>
-				<span>GLOSSAR</span>
+				<span class="uppercase">{{ t("GlossaryPage.title") }}</span>
 			</NuxtLink>
 		</div>
 	</MainContent>

--- a/pages/explore/journalistic-reception.vue
+++ b/pages/explore/journalistic-reception.vue
@@ -10,13 +10,15 @@ defineRouteRules({
 const t = useTranslations();
 
 usePageMetadata({
-	title: t("AboutPage.meta.title"),
+	title: t("JournalisticReceptionPage"),
 });
 
 const { data: about, error: aboutError } = useQuery({
-	queryKey: ["about"] as const,
+	queryKey: ["journalistic-reception"] as const,
 	queryFn() {
-		return queryContent<StaticPage>("pages/about/about-the-project").findOne();
+		return queryContent<StaticPage>(
+			"pages/journalistic-reception/journalistic-reception",
+		).findOne();
 	},
 });
 
@@ -38,8 +40,8 @@ watch(
 );
 
 useErrorMessage(aboutError, {
-	notFound: t("AboutPage.errors.404"),
-	unknown: t("AboutPage.errors.500"),
+	notFound: t("JournalisticReceptionPage.errors.404"),
+	unknown: t("JournalisticReceptionPage.errors.500"),
 });
 </script>
 
@@ -49,8 +51,8 @@ useErrorMessage(aboutError, {
 	>
 		<div class="flex md:justify-end">
 			<Card class="aspect-square size-full bg-frisch-grey md:size-72">
-				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
-					<h1 class="uppercase">{{ t("AboutPage.title") }}</h1>
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-frisch-indigo">
+					<h1>{{ t("JournalisticReceptionPage.title") }}</h1>
 				</CardContent>
 			</Card>
 		</div>

--- a/pages/explore/places.vue
+++ b/pages/explore/places.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { useQuery } from "@tanstack/vue-query";
+
+defineRouteRules({
+	prerender: true,
+});
+
+const t = useTranslations();
+
+usePageMetadata({
+	title: t("PlacesPage"),
+});
+
+const { data: places, error: aboutError } = useQuery({
+	queryKey: ["places"] as const,
+	queryFn() {
+		return queryContent("pages/places/places").findOne();
+	},
+});
+
+useErrorMessage(aboutError, {
+	notFound: t("PlacesPage.errors.404"),
+	unknown: t("PlacesPage.errors.500"),
+});
+</script>
+
+<template>
+	<MainContent
+		class="grid gap-8 p-4 md:grid-cols-[1fr_3fr] md:justify-center md:px-12 2xl:grid-cols-[2fr_3fr]"
+	>
+		<div class="flex md:justify-end">
+			<Card class="aspect-square size-full bg-frisch-orange md:size-72">
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
+					<h1 class="uppercase">{{ t("PlacesPage.title") }}</h1>
+				</CardContent>
+			</Card>
+		</div>
+
+		<ContentRenderer v-if="places" class="prose max-w-3xl" :value="places">
+			<template #empty></template>
+		</ContentRenderer>
+	</MainContent>
+</template>

--- a/pages/explore/research-aspects.vue
+++ b/pages/explore/research-aspects.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { useQuery } from "@tanstack/vue-query";
+
+defineRouteRules({
+	prerender: true,
+});
+
+const t = useTranslations();
+
+usePageMetadata({
+	title: t("ResearchAspectsPage"),
+});
+
+const { data: themes, error: aboutError } = useQuery({
+	queryKey: ["research-aspects"] as const,
+	queryFn() {
+		return queryContent("pages/research-aspects/research-aspects").findOne();
+	},
+});
+
+useErrorMessage(aboutError, {
+	notFound: t("ResearchAspectsPage.errors.404"),
+	unknown: t("ResearchAspectsPage.errors.500"),
+});
+</script>
+
+<template>
+	<MainContent
+		class="grid gap-8 p-4 md:grid-cols-[1fr_3fr] md:justify-center md:px-12 2xl:grid-cols-[2fr_3fr]"
+	>
+		<div class="flex md:justify-end">
+			<Card class="aspect-square size-full bg-frisch-orange md:size-72">
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
+					<h1 class="uppercase">{{ t("ResearchAspectsPage.title") }}</h1>
+				</CardContent>
+			</Card>
+		</div>
+
+		<ContentRenderer v-if="themes" class="prose max-w-3xl" :value="themes">
+			<template #empty></template>
+		</ContentRenderer>
+	</MainContent>
+</template>

--- a/pages/explore/themes.vue
+++ b/pages/explore/themes.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { useQuery } from "@tanstack/vue-query";
+
+defineRouteRules({
+	prerender: true,
+});
+
+const t = useTranslations();
+
+usePageMetadata({
+	title: t("ThemesPage"),
+});
+
+const { data: themes, error: aboutError } = useQuery({
+	queryKey: ["themes"] as const,
+	queryFn() {
+		return queryContent("pages/themes/themes").findOne();
+	},
+});
+
+useErrorMessage(aboutError, {
+	notFound: t("ThemesPage.errors.404"),
+	unknown: t("ThemesPage.errors.500"),
+});
+</script>
+
+<template>
+	<MainContent
+		class="grid gap-8 p-4 md:grid-cols-[1fr_3fr] md:justify-center md:px-12 2xl:grid-cols-[2fr_3fr]"
+	>
+		<div class="flex md:justify-end">
+			<Card class="aspect-square size-full bg-frisch-orange md:size-72">
+				<CardContent class="flex size-full py-4 text-2xl font-bold text-white">
+					<h1 class="uppercase">{{ t("ThemesPage.title") }}</h1>
+				</CardContent>
+			</Card>
+		</div>
+
+		<ContentRenderer v-if="themes" class="prose max-w-3xl" :value="themes">
+			<template #empty></template>
+		</ContentRenderer>
+	</MainContent>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@acdh-oeaw/tsconfig':
         specifier: ^1.2.0
         version: 1.2.0(typescript@5.6.3)
+      '@babel/plugin-transform-named-capturing-groups-regex':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.25.9)
       '@nuxt/devtools':
         specifier: ^1.6.0
         version: 1.6.0(rollup@4.24.0)(vite@5.4.10(@types/node@20.17.0)(terser@5.36.0))(vue@3.5.12(typescript@5.6.3))
@@ -222,6 +225,9 @@ importers:
       vite:
         specifier: ^5.4.10
         version: 5.4.10(@types/node@20.17.0)(terser@5.36.0)
+      vite-plugin-babel:
+        specifier: ^1.3.0
+        version: 1.3.0(@babel/core@7.25.9)(vite@5.4.10(@types/node@20.17.0)(terser@5.36.0))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.6.3)
@@ -321,6 +327,12 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.25.9':
     resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-regexp-features-plugin@7.26.3':
+    resolution: {integrity: sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -426,6 +438,12 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9':
+    resolution: {integrity: sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/plugin-transform-typescript@7.25.9':
     resolution: {integrity: sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==}
@@ -4972,12 +4990,30 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  regenerate-unicode-properties@10.2.0:
+    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
+    engines: {node: '>=4'}
+
+  regenerate@1.4.2:
+    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
   regex@4.3.3:
     resolution: {integrity: sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  regexpu-core@6.2.0:
+    resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
+    engines: {node: '>=4'}
+
+  regjsgen@0.8.0:
+    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+
+  regjsparser@0.12.0:
+    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
+    hasBin: true
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
@@ -5670,8 +5706,24 @@ packages:
   unhead@1.11.10:
     resolution: {integrity: sha512-hypXrAI47wE3wIhkze0RMPGAWcoo45Q1+XzdqLD/OnTCzjFXQrpuE4zBy8JRexyrqp+Ud2+nFTUNf/mjfFSymw==}
 
+  unicode-canonical-property-names-ecmascript@2.0.1:
+    resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
+    engines: {node: '>=4'}
+
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-ecmascript@2.0.0:
+    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-value-ecmascript@2.2.0:
+    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
+    engines: {node: '>=4'}
+
+  unicode-property-aliases-ecmascript@2.1.0:
+    resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
 
   unicode-trie@2.0.0:
@@ -5843,6 +5895,12 @@ packages:
     resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-plugin-babel@1.3.0:
+    resolution: {integrity: sha512-C5WKX0UwvQKH8WD2GiyWUjI62UBfLbfUhiLexnIm4asLdENX5ymrRipFlBnGeVxoOaYgTL5dh5KW6YDGpWsR8A==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
   vite-plugin-checker@0.8.0:
     resolution: {integrity: sha512-UA5uzOGm97UvZRTdZHiQVYFnd86AVn8EVaD4L3PoVzxH+IZSfaAw14WGFwX9QS23UW3lV/5bVKZn6l0w+q9P0g==}
@@ -6372,6 +6430,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-regexp-features-plugin@7.26.3(@babel/core@7.25.9)':
+    dependencies:
+      '@babel/core': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.25.9
+      regexpu-core: 6.2.0
+      semver: 6.3.1
+
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
@@ -6489,6 +6554,12 @@ snapshots:
       '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.25.9)':
+    dependencies:
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.25.9)
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-typescript@7.25.9(@babel/core@7.25.9)':
     dependencies:
@@ -11847,12 +11918,33 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.11.1
 
+  regenerate-unicode-properties@10.2.0:
+    dependencies:
+      regenerate: 1.4.2
+
+  regenerate@1.4.2: {}
+
   regex@4.3.3: {}
 
   regexp-ast-analysis@0.7.1:
     dependencies:
       '@eslint-community/regexpp': 4.11.1
       refa: 0.12.1
+
+  regexpu-core@6.2.0:
+    dependencies:
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.0
+      regjsgen: 0.8.0
+      regjsparser: 0.12.0
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.0
+
+  regjsgen@0.8.0: {}
+
+  regjsparser@0.12.0:
+    dependencies:
+      jsesc: 3.0.2
 
   rehype-external-links@3.0.0:
     dependencies:
@@ -12743,7 +12835,18 @@ snapshots:
       '@unhead/shared': 1.11.10
       hookable: 5.5.3
 
+  unicode-canonical-property-names-ecmascript@2.0.1: {}
+
   unicode-emoji-modifier-base@1.0.0: {}
+
+  unicode-match-property-ecmascript@2.0.0:
+    dependencies:
+      unicode-canonical-property-names-ecmascript: 2.0.1
+      unicode-property-aliases-ecmascript: 2.1.0
+
+  unicode-match-property-value-ecmascript@2.2.0: {}
+
+  unicode-property-aliases-ecmascript@2.1.0: {}
 
   unicode-trie@2.0.0:
     dependencies:
@@ -12951,6 +13054,11 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-plugin-babel@1.3.0(@babel/core@7.25.9)(vite@5.4.10(@types/node@20.17.0)(terser@5.36.0)):
+    dependencies:
+      '@babel/core': 7.25.9
+      vite: 5.4.10(@types/node@20.17.0)(terser@5.36.0)
 
   vite-plugin-checker@0.8.0(eslint@8.57.1)(optionator@0.9.4)(stylelint@16.10.0(typescript@5.6.3))(typescript@5.6.3)(vite@5.4.10(@types/node@20.17.0)(terser@5.36.0))(vue-tsc@2.1.6(typescript@5.6.3)):
     dependencies:

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -262,7 +262,7 @@ collections:
   - name: biography
     label: Biografie-Einträge
     label_singular: Biografie-Einträge
-    # description: Pages
+    # description: Biography entries for the biography-page.
     folder: content/pages/biography
     identifier_field: year
     create: true
@@ -304,7 +304,36 @@ collections:
 
       - name: body
         label: Content
-        # hint: The short biography
+        hint: The short biography
+        widget: markdown
+        modes:
+          # - raw
+          - rich_text
+  - name: quotes
+    label: Zitate
+    label_singular: Zitate
+    # description: Quotes for the explore page.
+    folder: content/pages/quotes
+    create: true
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: title
+        hint: For recognition in the cms.
+        widget: string
+        required: true
+
+      - name: link
+        label: Link to the related work
+        # hint: Provide the plain link-text, not link it here.
+        widget: string
+        required: false
+
+      - name: body
+        label: Quote
         widget: markdown
         modes:
           # - raw

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -167,6 +167,98 @@ collections:
             modes:
               # - raw
               - rich_text
+  - name: places
+    label: Orte-Intro
+    label_singular: Orte-Intro
+    # description: Pages
+    folder: content/pages/places
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: body
+        label: Content
+        i18n: true
+        # hint: The content
+        widget: markdown
+        modes:
+          # - raw
+          - rich_text
+  - name: themes
+    label: Themen-Intro
+    label_singular: Themen-Intro
+    # description: Pages
+    folder: content/pages/themes
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: body
+        label: Content
+        i18n: true
+        # hint: The content
+        widget: markdown
+        modes:
+          # - raw
+          - rich_text
+  - name: research-aspects
+    label: Forschungshinsichten-Intro
+    label_singular: Forschungshinsichten-Intro
+    # description: Pages
+    folder: content/pages/research-aspects
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: body
+        label: Content
+        i18n: true
+        # hint: The content
+        widget: markdown
+        modes:
+          # - raw
+          - rich_text
+  - name: glossary
+    label: Glossar-Intro
+    label_singular: Glossar-Intro
+    # description: Pages
+    folder: content/pages/glossary
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: body
+        label: Content
+        i18n: true
+        # hint: The content
+        widget: markdown
+        modes:
+          # - raw
+          - rich_text
   - name: biography
     label: Biografie-Einträge
     label_singular: Biografie-Einträge

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -51,6 +51,122 @@ collections:
             modes:
               # - raw
               - rich_text
+  - name: academic-reception
+    label: Akademische Rezeption
+    label_singular: Akademische Rezeption
+    # description: Pages
+    folder: content/pages/academic-reception
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: sections
+        label: Sections
+        # hint: The content
+        widget: list
+        fields:
+          - label: Title
+            name: title
+            widget: string
+          - label: Content
+            name: content
+            widget: markdown
+            modes:
+              # - raw
+              - rich_text
+  - name: journalistic-reception
+    label: Journalistische Rezeption
+    label_singular: Journalistische Rezeption
+    # description: Pages
+    folder: content/pages/journalistic-reception
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: sections
+        label: Sections
+        # hint: The content
+        widget: list
+        fields:
+          - label: Title
+            name: title
+            widget: string
+          - label: Content
+            name: content
+            widget: markdown
+            modes:
+              # - raw
+              - rich_text
+  - name: autobiografiction
+    label: Autobiografiktion
+    label_singular: Autobiografiktion
+    # description: Pages
+    folder: content/pages/autobiografiction
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: sections
+        label: Sections
+        # hint: The content
+        widget: list
+        fields:
+          - label: Title
+            name: title
+            widget: string
+          - label: Content
+            name: content
+            widget: markdown
+            modes:
+              # - raw
+              - rich_text
+  - name: from-the-archive
+    label: Aus dem Archiv
+    label_singular: Aus dem Archiv
+    # description: Pages
+    folder: content/pages/from-the-archive
+    create: false
+    delete: true
+    # nested:
+    #   depth: 3
+    # meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - name: title
+        label: Title
+        # hint: The title
+
+      - name: sections
+        label: Sections
+        # hint: The content
+        widget: list
+        fields:
+          - label: Title
+            name: title
+            widget: string
+          - label: Content
+            name: content
+            widget: markdown
+            modes:
+              # - raw
+              - rich_text
   - name: biography
     label: Biografie-Einträge
     label_singular: Biografie-Einträge

--- a/types/content.ts
+++ b/types/content.ts
@@ -21,3 +21,8 @@ export interface BiographyEntry extends MarkdownParsedContent {
 	imageTitle?: string;
 	copyright?: string;
 }
+
+export interface Quote extends MarkdownParsedContent {
+	title: string;
+	link: string;
+}

--- a/types/content.ts
+++ b/types/content.ts
@@ -1,6 +1,6 @@
 import type { MarkdownParsedContent } from "@nuxt/content";
 
-export interface AboutPage extends MarkdownParsedContent {
+export interface StaticPage extends MarkdownParsedContent {
 	title: string;
 	sections: Array<{
 		title: string;


### PR DESCRIPTION
Implemented static content pages (like the about page) for several explore pages + also added intro sections to place, themes, research-aspects and glossary pages. (editable via cms)

Implemented randomized quotes for the explore page. (editable via the cms)

closes #17 
closes #16 